### PR TITLE
#1 Problem: Fix issue with counting incoming WS messages

### DIFF
--- a/internal/pkg/httpsrv/handler_websocket.go
+++ b/internal/pkg/httpsrv/handler_websocket.go
@@ -66,6 +66,7 @@ func (s *Server) handlerWebSocket(w http.ResponseWriter, r *http.Request) {
 					log.Printf("failed to unmarshal message: %v\n", err)
 					continue
 				}
+				s.incStats(watch.GetWatcherId()) // increment the stats every time we receive a new read request
 				watch.ResetCounter()
 			case <-doneCh:
 				return

--- a/internal/pkg/httpsrv/stats.go
+++ b/internal/pkg/httpsrv/stats.go
@@ -17,9 +17,9 @@ func (w *sessionStats) inc() {
 
 func (s *Server) incStats(id string) {
 	// Find and increment.
-	for _, ws := range s.sessionStats {
+	for i, ws := range s.sessionStats {
 		if ws.id == id {
-			ws.inc()
+			s.sessionStats[i].inc()
 			return
 		}
 	}

--- a/internal/pkg/httpsrv/watcher.go
+++ b/internal/pkg/httpsrv/watcher.go
@@ -30,6 +30,5 @@ func (s *Server) notifyWatchers(str string) {
 	// Send message to all watchers and increment stats.
 	for id := range s.watchers {
 		s.watchers[id].Send(str)
-		s.incStats(id)
 	}
 }


### PR DESCRIPTION
This PR is fixing the #1 Problem mentioned in the README:

- The incrementing of the stats has been moved to the incoming message handler
- sessionStats is correctly identified through the stats list
- incrementing of the stats has been removed from watchers loop