### PR TITLE
Feature A: Add random hexadecimal string generator functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,9 @@ goapp:
 clean:
 	go clean
 	rm -f bin/*
+
+test:
+	go test -v ./...
+
+test-bench:
+	go test ./... -bench=.

--- a/internal/pkg/strgen/strgen.go
+++ b/internal/pkg/strgen/strgen.go
@@ -38,7 +38,7 @@ func (s *StringGenerator) mainLoop() {
 
 	for {
 		select {
-		case s.strChan <- util.RandString(10):
+		case s.strChan <- util.RandHexString(10):
 		case <-s.quitChannel:
 			return
 		default:

--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -6,6 +6,18 @@ import (
 
 var randx = rand.NewSource(42)
 
+// RandHexString returns a random hexademical string of length n.
+func RandHexString(n int) string {
+	const hexChars = "0123456789ABCDEF"
+
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = hexChars[rand.Intn(len(hexChars))]
+	}
+
+	return string(b)
+}
+
 // RandString returns a random string of length n.
 func RandString(n int) string {
 	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/pkg/util/string_test.go
+++ b/pkg/util/string_test.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGenerateHexString(t *testing.T) {
+	// Test string length
+	hexStr := RandHexString(16)
+	if len(hexStr) != 16 {
+		t.Errorf("Expected length 16, got %d", len(hexStr))
+	}
+
+	// Test hex format
+	match, _ := regexp.MatchString("^[0-9A-F]+$", hexStr)
+	if !match {
+		t.Errorf("Expected hex string, got %s", hexStr)
+	}
+}
+
+func BenchmarkGenerateHexString(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		RandHexString(16)
+	}
+}


### PR DESCRIPTION
This PR is implementing feature A updating the random string generator to produce hexadecimal numbers:

- Updates the random generator to return hex values
- Creates a unit test for `RandHexString` function
- Creates a benchmark test for `RandHexString` function
- Add `test` and `test-bench` commands to Makefile