### PR TITLE
Feature C: Add new command line client supporting multiple concurrent websocket connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ goapp:
 run: all
 	./bin/server
 
+.PHONY: run-concurrent
+run-concurrent: all
+	@$(eval connections ?= 1)
+	./bin/client -n $(connections)
+
 .PHONY: clean
 clean:
 	go clean

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
@@ -26,8 +27,12 @@ func main() {
 	exitChannel := make(chan os.Signal, 1)
 	signal.Notify(exitChannel, syscall.SIGINT, syscall.SIGTERM)
 
+	// Parse the number of parallel websocket connections
+	numOfConnections := flag.Int("n", 1, "Number of parallel WebSocket connections")
+	flag.Parse()
+
 	// Start.
-	if err := goapp.Start(exitChannel, false, 1); err != nil {
+	if err := goapp.Start(exitChannel, true, *numOfConnections); err != nil {
 		log.Fatalf("fatal: %+v\n", err)
 	}
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -31,6 +31,11 @@ func main() {
 	numOfConnections := flag.Int("n", 1, "Number of parallel WebSocket connections")
 	flag.Parse()
 
+	if *numOfConnections <= 0 {
+		log.Fatal("Number of connections must be higher than 0")
+		<-exitChannel
+	}
+
 	// Start.
 	if err := goapp.Start(exitChannel, true, *numOfConnections); err != nil {
 		log.Fatalf("fatal: %+v\n", err)

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -8,11 +8,11 @@ import (
 	"os"
 )
 
-func Start(exitChannel chan os.Signal) error {
+func Start(exitChannel chan os.Signal, concurrent bool, numOfConnections int) error {
 	var (
-		strChan = make(chan string, 100) // String channel with max parallel counter processes.
-		strCli  = strgen.New(strChan)    // String generator.
-		httpSrv = httpsrv.New(strChan)   // HTTP server.
+		strChan = make(chan string, 100)                             // String channel with max parallel counter processes.
+		strCli  = strgen.New(strChan)                                // String generator.
+		httpSrv = httpsrv.New(strChan, concurrent, numOfConnections) // HTTP server.
 	)
 
 	// Start String Generator.

--- a/internal/pkg/httpsrv/handler_home.go
+++ b/internal/pkg/httpsrv/handler_home.go
@@ -55,7 +55,6 @@ window.addEventListener("load", function(evt) {
             }
             newWs.onclose = function(evt) {
                 print("CLOSE", i);
-                ws.splice(i, 1);
             }
             newWs.onmessage = function(evt) {
                 print("RESPONSE: " + evt.data, i);
@@ -80,9 +79,8 @@ window.addEventListener("load", function(evt) {
         if (ws.length === 0) {
             return false;
         }
-        for (let i = 0; i < numConnections; i++) {
-            ws[i].close();
-        }
+        ws.forEach((websocket) => websocket.close());
+        ws = [];
         return false;
     };
 });

--- a/internal/pkg/httpsrv/handler_home.go
+++ b/internal/pkg/httpsrv/handler_home.go
@@ -15,6 +15,12 @@ func (s *Server) handlerHome(w http.ResponseWriter, r *http.Request) {
 	// Set the CSRF token as a cookie
 	SetCSRFCookie(w, csrfToken)
 
+	varmap := map[string]interface{}{
+		"host":                  "ws://" + r.Host + "/goapp/ws",
+		"numOfConnections":      s.numOfConnections,
+		"concurrentConnections": s.concurrentWSConnections,
+	}
+
 	template.Must(template.New("").Parse(`
 <!DOCTYPE html>
 <html>
@@ -24,46 +30,59 @@ func (s *Server) handlerHome(w http.ResponseWriter, r *http.Request) {
 window.addEventListener("load", function(evt) {
     var output = document.getElementById("output");
     var input = document.getElementById("input");
-    var ws;
-    var print = function(message) {
+    var ws = [];
+    var numConnections = Number("{{.numOfConnections}}");
+    var concurrentConnections = "{{.concurrentConnections}}";
+    var print = function(message, i) {
+        let prefix = "";
+        if (concurrentConnections === "true" && numConnections > 1) {
+            prefix = "[conn #" + i + "] ";
+        }
         var d = document.createElement("div");
-        d.textContent = message;
+        d.textContent = prefix + message;
         output.appendChild(d);
         output.scroll(0, output.scrollHeight);
     };
     document.getElementById("open").onclick = function(evt) {
-        if (ws) {
+        if (ws.length !== 0) {
             return false;
         }
-        ws = new WebSocket("{{.}}");
-        ws.onopen = function(evt) {
-            print("OPEN");
-        }
-        ws.onclose = function(evt) {
-            print("CLOSE");
-            ws = null;
-        }
-        ws.onmessage = function(evt) {
-            print("RESPONSE: " + evt.data);
-        }
-        ws.onerror = function(evt) {
-            print("ERROR: " + evt.data);
+        for (let i = 0; i < numConnections; i++) {
+            let newWs = new WebSocket("{{.host}}");
+            ws.push(newWs);
+            newWs.onopen = function(evt) {
+                print("OPEN", i);
+            }
+            newWs.onclose = function(evt) {
+                print("CLOSE", i);
+                ws.splice(i, 1);
+            }
+            newWs.onmessage = function(evt) {
+                print("RESPONSE: " + evt.data, i);
+            }
+            newWs.onerror = function(evt) {
+                print("ERROR: " + evt.data, i);
+            }
         }
         return false;
     };
     document.getElementById("send").onclick = function(evt) {
-        if (!ws) {
+        if (ws.length === 0) {
             return false;
         }
-        print("SEND: " + input.value);
-        ws.send(input.value);
+        for (let i = 0; i < numConnections; i++) {
+            print("SEND: " + input.value, i);
+            ws[i].send(input.value);
+        }
         return false;
     };
     document.getElementById("close").onclick = function(evt) {
-        if (!ws) {
+        if (ws.length === 0) {
             return false;
         }
-        ws.close();
+        for (let i = 0; i < numConnections; i++) {
+            ws[i].close();
+        }
         return false;
     };
 });
@@ -87,5 +106,5 @@ You can change the message and send multiple times.
 </td></tr></table>
 </body>
 </html>
-`)).Execute(w, "ws://"+r.Host+"/goapp/ws")
+`)).Execute(w, varmap)
 }

--- a/internal/pkg/httpsrv/server.go
+++ b/internal/pkg/httpsrv/server.go
@@ -15,16 +15,18 @@ import (
 )
 
 type Server struct {
-	strChan      <-chan string               // String channel.
-	server       *http.Server                // Gorilla HTTP server.
-	watchers     map[string]*watcher.Watcher // Counter watchers (k: counterId).
-	watchersLock *sync.RWMutex               // Counter lock.
-	sessionStats []sessionStats              // Session stats.
-	quitChannel  chan struct{}               // Quit channel.
-	running      sync.WaitGroup              // Running goroutines.
+	strChan                 <-chan string               // String channel.
+	server                  *http.Server                // Gorilla HTTP server.
+	watchers                map[string]*watcher.Watcher // Counter watchers (k: counterId).
+	watchersLock            *sync.RWMutex               // Counter lock.
+	sessionStats            []sessionStats              // Session stats.
+	quitChannel             chan struct{}               // Quit channel.
+	running                 sync.WaitGroup              // Running goroutines.
+	concurrentWSConnections bool                        // Session Concurrency.
+	numOfConnections        int                         // Number of Websocket sessions.
 }
 
-func New(strChan <-chan string) *Server {
+func New(strChan <-chan string, concurrentWSConnections bool, numOfConnections int) *Server {
 	s := Server{}
 	s.strChan = strChan
 	s.server = nil // Set below.
@@ -33,6 +35,8 @@ func New(strChan <-chan string) *Server {
 	s.sessionStats = []sessionStats{}
 	s.quitChannel = make(chan struct{})
 	s.running = sync.WaitGroup{}
+	s.concurrentWSConnections = concurrentWSConnections
+	s.numOfConnections = numOfConnections
 	return &s
 }
 


### PR DESCRIPTION
This PR Is implementing Feature C as described in the README. More specifically:

- Added a new command line `client` that is accepting a `-n` flag with the number of concurrent websocket connections
- Modify the server code to accept the new flag and open multiple websocket connections
- Add a `run-concurrent` command to Makefile to run the `client` cmd