### PR TITLE
Issue #2: Fix memory leak when websockets are piling up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,18 @@ clean:
 	go clean
 	rm -f bin/*
 
+.PHONY: test
 test:
 	go test -v ./...
 
+.PHONY: test-bench
 test-bench:
 	go test ./... -bench=.
+
+.PHONY: install-loadtesting-deps
+install-loadtesting-deps:
+	npm i -g artillery
+
+.PHONY: run-loadtesting
+run-loadtesting:
+	artillery run websocket_loadtesting.yml

--- a/websocket_loadtesting.yml
+++ b/websocket_loadtesting.yml
@@ -11,4 +11,4 @@ scenarios:
         - send:
           x: 0
           y: 0
-        count: 100
+        count: 5

--- a/websocket_loadtesting.yml
+++ b/websocket_loadtesting.yml
@@ -1,0 +1,14 @@
+config:
+  target: "ws://localhost:8080/goapp/ws"
+  phases:
+    - duration: 120
+      arrivalRate: 20
+
+scenarios:
+  - engine: ws
+    flow:
+      - loop:
+        - send:
+          x: 0
+          y: 0
+        count: 100


### PR DESCRIPTION
This PR is adding the needed tools (https://www.artillery.io) to loadtest websockets. In order to run the loadtest CSRF validation needs to be disabled.

Running the memory profiler after loadtesting the websocket path we get the below results:

```
$ go tool pprof -sample_index=alloc_space http://localhost:6060/debug/pprof/heap

File: server
Type: alloc_space
Time: Aug 23, 2024 at 6:06pm (EEST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 109.28MB, 80.98% of 134.95MB total
Dropped 20 nodes (cum <= 0.67MB)
Showing top 10 nodes out of 64
      flat  flat%   sum%        cum   cum%
   47.68MB 35.33% 35.33%    47.68MB 35.33%  bufio.NewWriterSize (inline)
   21.08MB 15.62% 50.95%    21.08MB 15.62%  bufio.NewReaderSize
   16.51MB 12.23% 63.19%    16.51MB 12.23%  io.ReadAll
    5.50MB  4.08% 67.26%     5.50MB  4.08%  log.(*Logger).output
       4MB  2.96% 70.23%        4MB  2.96%  encoding/json.Unmarshal
    3.50MB  2.59% 72.82%     3.50MB  2.59%  github.com/gorilla/websocket.newConn
    3.50MB  2.59% 75.42%     3.50MB  2.59%  net/http.(*Request).WithContext
       3MB  2.22% 77.64%     3.50MB  2.59%  goapp/internal/pkg/watcher.New
    2.50MB  1.85% 79.49%     3.50MB  2.59%  net/textproto.readMIMEHeader
       2MB  1.48% 80.98%     9.50MB  7.04%  net/http.(*conn).readRequest
```

The memory leak seems to be encountered on `bufio.NewWriterSize`, `bufio.NewReaderSize` and `io.ReadAll` functions, probably because those buffers are not closing properly. The main component that is using the write and read buffers is the websocket handler.