### PR TITLE
Issue #3: Update CSRF implementation

### DIFF
--- a/internal/pkg/httpsrv/csrf.go
+++ b/internal/pkg/httpsrv/csrf.go
@@ -19,11 +19,12 @@ func GenerateCSRFToken() (string, error) {
 // CSRFMiddleware validates CSRF tokens for state-changing requests
 func CSRFMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodDelete {
-			csrfToken := r.Header.Get("X-CSRF-Token")
+		if r.Method == http.MethodGet || r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodDelete {
+			csrfToken := r.URL.Query().Get("csrf_token")
 			cookie, err := r.Cookie("csrf_token")
-			if err != nil || csrfToken != cookie.Value {
-				http.Error(w, "Invalid CSRF token", http.StatusForbidden)
+
+			if err != nil || csrfToken == "" || csrfToken != cookie.Value {
+				http.Error(w, "Unathorized request", http.StatusUnauthorized)
 				return
 			}
 		}

--- a/internal/pkg/httpsrv/handler_home.go
+++ b/internal/pkg/httpsrv/handler_home.go
@@ -16,7 +16,7 @@ func (s *Server) handlerHome(w http.ResponseWriter, r *http.Request) {
 	SetCSRFCookie(w, csrfToken)
 
 	varmap := map[string]interface{}{
-		"host":                  "ws://" + r.Host + "/goapp/ws",
+		"host":                  "ws://" + r.Host + "/goapp/ws?csrf_token=" + csrfToken,
 		"numOfConnections":      s.numOfConnections,
 		"concurrentConnections": s.concurrentWSConnections,
 	}

--- a/internal/pkg/httpsrv/routes.go
+++ b/internal/pkg/httpsrv/routes.go
@@ -32,7 +32,7 @@ func (s *Server) myRoutes() []Route {
 			Name:    "home",
 			Method:  "GET",
 			Pattern: "/goapp",
-			HFunc:   CSRFMiddleware(s.handlerWrapper(s.handlerHome)),
+			HFunc:   s.handlerWrapper(s.handlerHome),
 		},
 	}
 }


### PR DESCRIPTION
This PR is modifying the CSRF middleware implementation. More specifically:

- Using the middleware only for the Websocket handler
- Adding the CSRF token in the websocket query params
- Modifying the middleware to include all HTTP verbs (adding GET) and extracting the token from the query params